### PR TITLE
Upgrade the version of Helm to v3.0.0-alpha.2

### DIFF
--- a/kubecon2019china/charts/guestbook-kruise/README.md
+++ b/kubecon2019china/charts/guestbook-kruise/README.md
@@ -8,16 +8,16 @@ The chart use [Kruise](https://github.com/openkruise/kruise) as workloads so in-
 
 ## Installing Helm v3
 
-From [Helm v3 releases](https://github.com/helm/helm/releases/tag/v3.0.0-alpha.1).
+From [Helm v3 releases](https://github.com/helm/helm/releases/tag/v3.0.0-alpha.2).
 
 Or, some of Helm v3 Latest Release on Aliyun OSS:
 
-* [MacOS amd64 tar.gz](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-darwin-amd64.tar.gz)
-* [MacOS amd64 zip](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-darwin-amd64.zip)
-* [Linux 386](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-linux-386.tar.gz)
-* [Linux amd64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-linux-amd64.tar.gz) 
-* [Linux arm64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-linux-arm64.tar.gz)
-* [Windows amd64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-windows-amd64.zip)
+* [MacOS amd64 tar.gz](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-darwin-amd64.tar.gz)
+* [MacOS amd64 zip](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-darwin-amd64.zip)
+* [Linux 386](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-linux-386.tar.gz)
+* [Linux amd64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-linux-amd64.tar.gz)
+* [Linux arm64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-linux-arm64.tar.gz)
+* [Windows amd64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-windows-amd64.zip)
 
 
 ## Installing Kruise

--- a/kubecon2019china/charts/guestbook/README.md
+++ b/kubecon2019china/charts/guestbook/README.md
@@ -6,16 +6,16 @@ The chart installs a [guestbook](https://github.com/cloudnativeapp/guestbook) ap
 
 ## Installing Helm v3
 
-From [Helm v3 releases](https://github.com/helm/helm/releases/tag/v3.0.0-alpha.1).
+From [Helm v3 releases](https://github.com/helm/helm/releases/tag/v3.0.0-alpha.2).
 
 Or, some of Helm v3 Latest Release on Aliyun OSS:
 
-* [MacOS amd64 tar.gz](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-darwin-amd64.tar.gz)
-* [MacOS amd64 zip](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-darwin-amd64.zip)
-* [Linux 386](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-linux-386.tar.gz)
-* [Linux amd64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-linux-amd64.tar.gz) 
-* [Linux arm64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-linux-arm64.tar.gz)
-* [Windows amd64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.1-windows-amd64.zip)
+* [MacOS amd64 tar.gz](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-darwin-amd64.tar.gz)
+* [MacOS amd64 zip](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-darwin-amd64.zip)
+* [Linux 386](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-linux-386.tar.gz)
+* [Linux amd64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-linux-amd64.tar.gz)
+* [Linux arm64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-linux-arm64.tar.gz)
+* [Windows amd64](https://cloudnativeapphub.oss-cn-hangzhou.aliyuncs.com/helm-v3.0.0-alpha.2-windows-amd64.zip)
 
 ## Installing the Chart
 


### PR DESCRIPTION
Helm v3.0.0-alpha.1 has the issue of `helm dep update` which
will result in failure of charts which have dependency.